### PR TITLE
Replace custom fonts with monospace

### DIFF
--- a/assets/scss/debug.scss
+++ b/assets/scss/debug.scss
@@ -54,5 +54,5 @@
 
 }
     .font1 {
-        font-family: "freightsans pro";
+        font-family: monospace;
     }

--- a/assets/scss/typography.scss
+++ b/assets/scss/typography.scss
@@ -6,7 +6,7 @@ body,
 h1 .nickname,
 main blockquote.quote,
 .form .field--label[data-required]:after {
-    font-family: "adelle-sans", calibri, sans-serif;
+    font-family: monospace;
     font-weight: 300;
     font-style: normal;
 }
@@ -24,7 +24,7 @@ h5,
 h6,
 blockquote.quote *,
 .form .field--label {
-    font-family: "jubilat", georgia, serif;
+    font-family: monospace;
     font-weight: 400;
     font-style: normal;
 
@@ -42,7 +42,7 @@ main h4,
 main h5,
 main h6,
 main .section p:first-of-type:first-letter {
-    font-family: "jubilat", georgia, serif;
+    font-family: monospace;
     font-weight: 700;
     font-style: normal;
 }


### PR DESCRIPTION
## What changed
Updated all typeface declarations to use monospace fonts across the codebase. This affects:
- Body text, nicknames, blockquotes, and form labels (previously using "adelle-sans")
- All heading levels h1-h6 (previously using "jubilat")
- Debug styles (previously using "freightsans pro")

Icon fonts remain unchanged as they serve a different purpose.

## Why
Standardizing on monospace typography provides a consistent, code-friendly aesthetic throughout the application. This simplifies the font stack and removes dependencies on custom web fonts.

---

This PR was created by [Graphite Agent](https://app.graphite.com/background-agents/andr3/meet.andr3.net/task/bgt_01kea3cceyffyrcnnqp82fzhdx)
